### PR TITLE
Refactor server.json to use snake_case for registry_type;

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -66,10 +66,21 @@ jobs:
 
       - name: Install MCP Publisher
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/latest/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          # Try Homebrew first (most reliable), fallback to direct download
+          if command -v brew >/dev/null 2>&1; then
+            brew install mcp-publisher
+          else
+            # Fallback to direct download with proper release detection
+            LATEST_RELEASE=$(curl -s https://api.github.com/repos/modelcontextprotocol/registry/releases/latest | grep "tag_name" | cut -d '"' -f 4)
+            OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+            ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+            curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${LATEST_RELEASE}/mcp-publisher_${OS}_${ARCH}.tar.gz" | tar xz
+            chmod +x mcp-publisher
+            sudo mv mcp-publisher /usr/local/bin/
+          fi
 
       - name: Login to MCP Registry
-        run: ./mcp-publisher login github-oidc
+        run: mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+        run: mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
   ],
   "packages": [
     {
-      "registryType": "npm",
+      "registry_type": "npm",
       "identifier": "docfork",
       "version": "1.0.0",
       "transport": {


### PR DESCRIPTION
enhance npm-publish workflow to install MCP Publisher via Homebrew or direct download with proper release detection